### PR TITLE
Fix connection for resort scenario and add FAQ search

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -27,12 +27,14 @@ import { chatSupervisorScenario } from "@/app/agentConfigs/chatSupervisor";
 import { customerServiceRetailCompanyName } from "@/app/agentConfigs/customerServiceRetail";
 import { chatSupervisorCompanyName } from "@/app/agentConfigs/chatSupervisor";
 import { simpleHandoffScenario } from "@/app/agentConfigs/simpleHandoff";
+import { resortHelperScenario } from "@/app/agentConfigs/resortHelper";
 
 // Map used by connect logic for scenarios defined via the SDK.
 const sdkScenarioMap: Record<string, RealtimeAgent[]> = {
   simpleHandoff: simpleHandoffScenario,
   customerServiceRetail: customerServiceRetailScenario,
   chatSupervisor: chatSupervisorScenario,
+  resortHelper: resortHelperScenario,
 };
 
 import useAudioDownload from "./hooks/useAudioDownload";

--- a/src/app/agentConfigs/resortHelper.ts
+++ b/src/app/agentConfigs/resortHelper.ts
@@ -1,14 +1,46 @@
 import {
   RealtimeAgent,
+  tool,
 } from '@openai/agents/realtime';
+
+import faqs from '../../data/flat_faqs.json';
+
+const lookupFaq = tool({
+  name: 'lookupFAQ',
+  description:
+    'Look up an answer from the resort FAQ list using a question or keyword.',
+  parameters: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'The user question or keywords to search for.',
+      },
+    },
+    required: ['query'],
+    additionalProperties: false,
+  },
+  execute: async (input: any) => {
+    const { query } = input as { query: string };
+    const q = query.toLowerCase();
+    const match = (faqs as any[]).find(
+      (faq) =>
+        faq.question.toLowerCase().includes(q) ||
+        (faq.keywords || []).some((k: string) =>
+          k.toLowerCase().includes(q) || q.includes(k.toLowerCase()),
+        ),
+    );
+    return { answer: match ? match.answer : null };
+  },
+});
 
 export const resortAgent = new RealtimeAgent({
   name: 'resortAgent',
   voice: 'alloy',
   instructions:
-    'You help guests at a tropical resort. Answer questions about amenities and services.',
+    'You help guests at a tropical resort. Answer questions about amenities and services. Use the lookupFAQ tool whenever possible.',
   handoffs: [],
-  tools: [],
+  tools: [lookupFaq],
   handoffDescription: 'Resort helper agent',
 });
 


### PR DESCRIPTION
## Summary
- add a FAQ lookup tool and integrate it with the `resortAgent`
- include the resort agent in the SDK scenario map so connections succeed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd17351608320aa07870a66f619a9