### PR TITLE
Improve Coco agent FAQ handling

### DIFF
--- a/src/app/agentConfigs/faqs.ts
+++ b/src/app/agentConfigs/faqs.ts
@@ -1,0 +1,11 @@
+import data from '../../../data/flat_faqs.json';
+
+export interface FAQ {
+  category: string;
+  question: string;
+  keywords: string[];
+  answer: string;
+  embedding?: number[];
+}
+
+export const faqs: FAQ[] = data as FAQ[];


### PR DESCRIPTION
## Summary
- add `faqs.ts` to expose resort FAQ list on the frontend
- make Coco use `lookupFAQ` to search these FAQs before falling back to GPT
- update Coco's instructions to clarify FAQ-first behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a8e68d8c8320ac7a310f650f20f1